### PR TITLE
Update the dependencies to enable the plugin in the latest version of Bamboo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
     </scm>
 
     <properties>
-        <bamboo.version>8.2.6</bamboo.version>
+        <bamboo.version>10.2.1</bamboo.version>
         <bamboo.data.version>${bamboo.version}</bamboo.data.version>
-        <amps.version>8.8.0</amps.version>
-        <atlassian.spring.scanner.version>3.0.2</atlassian.spring.scanner.version>
+        <amps.version>9.2.6</amps.version>
+        <atlassian.spring.scanner.version>3.0.3</atlassian.spring.scanner.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -96,22 +96,15 @@
                     <productVersion>${bamboo.version}</productVersion>
                     <productDataVersion>${bamboo.data.version}</productDataVersion>
                     <enableQuickReload>true</enableQuickReload>
-                    <enableFastdev>false</enableFastdev>
-
                     <!-- See here for an explanation of default instructions: -->
                     <!-- https://developer.atlassian.com/docs/advanced-topics/configuration-of-instructions-in-atlassian-plugins -->
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
-
                         <!-- Add package to export here -->
                         <Export-Package>
                         </Export-Package>
-
                         <!-- Add package import here -->
-                        <Import-Package>
-                            *
-                        </Import-Package>
-
+                        <Import-Package>*</Import-Package>
                         <!-- Ensure plugin is spring powered -->
                         <Spring-Context>*</Spring-Context>
                     </instructions>

--- a/src/main/java/com/parasoft/findings/bamboo/ReportCollector.java
+++ b/src/main/java/com/parasoft/findings/bamboo/ReportCollector.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -46,7 +48,6 @@ import com.atlassian.bamboo.build.test.TestCollectionResult;
 import com.atlassian.bamboo.build.test.TestCollectionResultBuilder;
 import com.atlassian.bamboo.build.test.TestReportCollector;
 import com.atlassian.bamboo.build.test.junit.JunitTestResultsParser;
-import com.google.common.collect.Sets;
 
 
 public class ReportCollector implements TestReportCollector {
@@ -93,7 +94,7 @@ public class ReportCollector implements TestReportCollector {
 
     @Override
     public Set<String> getSupportedFileExtensions() {
-        return Sets.newHashSet("xml"); //$NON-NLS-1$
+        return new HashSet<>(Collections.singleton("xml")); //$NON-NLS-1$
     }
 
     private ReportType getReportType(File from) throws XMLStreamException {


### PR DESCRIPTION
**Requirement:**
-  JDK 17+
-  Atlassian SDK: atlassian-plugin-sdk-9.1.1. 
    - Download: https://maven.artifacts.atlassian.com/com/atlassian/amps/atlassian-plugin-sdk/

**Package the plugin:**
1. Create a .mvn/maven.config file in the project root directory according to local maven version:
    - For Maven 3.9.0 or maybe later:
      >    -gs
      >    "D:\Programs\Atlassian\atlassian-plugin-sdk-9.1.1\apache-maven-3.9.8\conf\settings.xml"

    - For Maven 3.6.3+ and prior to 3.9.0:
      > -gs "D:\Programs\Atlassian\atlassian-plugin-sdk-9.1.1\apache-maven-3.9.8\conf\settings.xml"
2. Run _mvn package_ in project root directory.

**Install plugin to Bamboo:**
1. Copy the plugin to <Bamboo home path>/shared/plugins.
2. Start the Bamboo.

**For lower versions of Bamboo, plugins can also be installed this way:**
1. Start the Bamboo.
2. Click the Setting gear -> Manage apps(or Add-ons) -> Upload app(or Upload add-on) and choose your plugin jar file and click Upload.
![image](https://github.com/user-attachments/assets/e7026777-6461-4b61-826f-7e5a9487e8b9)



