### PR TITLE
Make the Bamboo plugin support the latest version of Bamboo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <bamboo.version>10.2.1</bamboo.version>
         <bamboo.data.version>${bamboo.version}</bamboo.data.version>
-        <amps.version>9.2.6</amps.version>
+        <amps.version>9.12.5</amps.version>
         <atlassian.spring.scanner.version>3.0.3</atlassian.spring.scanner.version>
         <saxon-he.version>12.3</saxon-he.version>
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->

--- a/src/main/resources/atlassian-plugin-marketing.xml
+++ b/src/main/resources/atlassian-plugin-marketing.xml
@@ -2,7 +2,7 @@
 
     <!-- Describe names and versions of compatible products -->
     <compatibility>
-        <product name="bamboo" min="6.1" max="10.2" />
+        <product name="bamboo" min="6.1" max="12.1" />
     </compatibility>
 
     <!-- Describe your app logo and banner. The banner is only displayed in the UPM. -->


### PR DESCRIPTION
The changes in this task has been verified in development environment with Atlassian Plugin SDK 9.1.1 in the following Bamboo versions.

Use Java 21 to run the latest Bamboo 12.1.8.

```sh
atlas-clean
atlas-run --version 12.1.8
```

Use Java 21 to run the default Bamboo 10.2.1.

```sh
atlas-clean
atlas-run
```

Or Bamboo 10.2.20.

```sh
atlas-clean
atlas-run --version 10.2.20
```

Use Java 17 to run the Bamboo 9.6.27.

```sh
atlas-clean
atlas-run --version 9.6.27
```

Use Java 11 to run the Bamboo 9.2.24.

```sh
atlas-clean
atlas-run "-Dbamboo.version=9.2.24"
```

For earlier versions of Bamboo, the licenses of development environment Bamboo installations were expired, thus not verified.

References:

- [Install the Atlassian SDK on a Windows system](https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-windows-system/)
- [Atlassian Plugin SDK - TGZ - Version history | Atlassian Marketplace | Atlassian Marketplace](https://marketplace.atlassian.com/apps/1210993/atlassian-plugin-sdk-tgz/version-history?versionHistoryHosting=server)
- [Atlassian Plugin SDK - TGZ - Version history | Atlassian Marketplace | Atlassian Marketplace](https://marketplace.atlassian.com/apps/1210993/atlassian-plugin-sdk-tgz/version-history?versionHistoryHosting=dataCenter)
- [AMPS SDK release notes](https://developer.atlassian.com/server/framework/atlassian-sdk/amps-sdk-release-notes/)
- [Bamboo release notes | Atlassian Support | Atlassian Documentation](https://confluence.atlassian.com/bambooreleases/bamboo-release-notes-1189793869.html)
- [How to upgrade the Java version used by Bamboo | Bamboo | Atlassian Support](https://support.atlassian.com/bamboo/kb/how-to-upgrade-the-java-version-used-by-bamboo/?utm_source=chatgpt.com)
- [atlas-run](https://developer.atlassian.com/server/framework/atlassian-sdk/atlas-run/)
